### PR TITLE
fix: coerce transaction date

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -34,6 +34,8 @@ export const insights = pgTable("insights", {
 export const insertTransactionSchema = createInsertSchema(transactions).omit({
   id: true,
   createdAt: true,
+}).extend({
+  date: z.coerce.date(),
 });
 
 export const insertBudgetSchema = createInsertSchema(budgets).omit({


### PR DESCRIPTION
## Summary
- allow string dates when validating new transactions to prevent POST /api/transactions errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68ac932f3914832186f51bd8fd08eca1