### PR TITLE
feat: manage budgets and DH currency

### DIFF
--- a/client/src/components/add-transaction-modal.tsx
+++ b/client/src/components/add-transaction-modal.tsx
@@ -129,7 +129,7 @@ export default function AddTransactionModal({ isOpen, onClose }: AddTransactionM
           <div>
             <Label htmlFor="amount" className="text-sm font-medium text-gray-700 mb-2 block">Amount</Label>
             <div className="relative">
-              <span className="absolute left-3 top-3 text-gray-500">$</span>
+              <span className="absolute left-3 top-3 text-gray-500">DH</span>
               <Input
                 {...register("amount")}
                 type="number"

--- a/client/src/components/budget-tracking.tsx
+++ b/client/src/components/budget-tracking.tsx
@@ -5,6 +5,8 @@ import { useQuery } from "@tanstack/react-query";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Utensils, Car, Gamepad2, ShoppingBag, Zap, AlertTriangle, TrendingUp, BarChart3 } from "lucide-react";
+import { useState } from "react";
+import ManageBudgetsDialog from "@/components/manage-budgets-dialog";
 
 const categoryIcons = {
   "Food & Dining": Utensils,
@@ -26,6 +28,7 @@ export default function BudgetTracking() {
   const { data: budgets, isLoading } = useQuery<any[]>({
     queryKey: ["/api/budgets"],
   });
+  const [open, setOpen] = useState(false);
 
   const { data: insights } = useQuery<any[]>({
     queryKey: ["/api/insights"],
@@ -85,8 +88,10 @@ export default function BudgetTracking() {
   const formatCurrency = (amount: string) => {
     return new Intl.NumberFormat("en-US", {
       style: "currency",
-      currency: "USD",
-    }).format(parseFloat(amount));
+      currency: "MAD",
+    })
+      .format(parseFloat(amount))
+      .replace("MAD", "DH");
   };
 
   const calculateProgress = (spent: string, limit: string) => {
@@ -111,15 +116,17 @@ export default function BudgetTracking() {
   };
 
   return (
-    <Card className="bg-white rounded-xl shadow-sm border border-gray-200">
-      <CardHeader className="pb-6">
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-xl font-semibold text-foreground">Budget Overview</CardTitle>
-          <Button variant="ghost" className="text-primary hover:text-primary/80 font-medium text-sm" data-testid="button-manage-budgets">
+    <>
+      <ManageBudgetsDialog open={open} onOpenChange={setOpen} />
+      <Card className="bg-white rounded-xl shadow-sm border border-gray-200">
+        <CardHeader className="pb-6">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-xl font-semibold text-foreground">Budget Overview</CardTitle>
+          <Button variant="ghost" className="text-primary hover:text-primary/80 font-medium text-sm" data-testid="button-manage-budgets" onClick={() => setOpen(true)}>
             Manage Budgets
           </Button>
-        </div>
-      </CardHeader>
+          </div>
+        </CardHeader>
       
       <CardContent>
         <div className="space-y-6">
@@ -190,6 +197,7 @@ export default function BudgetTracking() {
           })}
         </div>
       </CardContent>
-    </Card>
+      </Card>
+    </>
   );
 }

--- a/client/src/components/financial-overview.tsx
+++ b/client/src/components/financial-overview.tsx
@@ -37,8 +37,10 @@ export default function FinancialOverview() {
   const formatCurrency = (amount: number) => {
     return new Intl.NumberFormat("en-US", {
       style: "currency",
-      currency: "USD",
-    }).format(amount);
+      currency: "MAD",
+    })
+      .format(amount)
+      .replace("MAD", "DH");
   };
 
   return (
@@ -58,7 +60,9 @@ export default function FinancialOverview() {
           </div>
           <div className="flex items-center mt-4">
             <span className="text-sm text-secondary font-medium" data-testid="text-balance-change">
-              {overview?.currentBalance > 0 ? `+${formatCurrency(Math.abs(overview.currentBalance))}` : formatCurrency(overview?.currentBalance || 0)} this month
+              {(overview?.currentBalance || 0) > 0
+                ? `+${formatCurrency(Math.abs(overview?.currentBalance || 0))}`
+                : formatCurrency(overview?.currentBalance || 0)} this month
             </span>
           </div>
         </CardContent>

--- a/client/src/components/manage-budgets-dialog.tsx
+++ b/client/src/components/manage-budgets-dialog.tsx
@@ -1,0 +1,108 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ChevronUp, ChevronDown } from "lucide-react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState, useEffect } from "react";
+
+interface ManageBudgetsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function ManageBudgetsDialog({ open, onOpenChange }: ManageBudgetsDialogProps) {
+  const { data: budgets } = useQuery<any[]>({ queryKey: ["/api/budgets"] });
+  const [values, setValues] = useState<Record<string, string>>({});
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (budgets) {
+      const initial: Record<string, string> = {};
+      budgets.forEach((b) => {
+        initial[b.category] = b.monthlyLimit;
+      });
+      setValues(initial);
+    }
+  }, [budgets]);
+
+  const updateBudget = useMutation({
+    mutationFn: async ({ category, monthlyLimit }: { category: string; monthlyLimit: string }) => {
+      const res = await fetch(`/api/budgets/${encodeURIComponent(category)}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ monthlyLimit }),
+      });
+      if (!res.ok) throw new Error("Failed to update budget");
+      return res.json();
+    },
+  });
+
+  const handleSave = async () => {
+    await Promise.all(
+      Object.entries(values).map(([category, monthlyLimit]) =>
+        updateBudget.mutateAsync({ category, monthlyLimit })
+      )
+    );
+    queryClient.invalidateQueries({ queryKey: ["/api/budgets"] });
+    onOpenChange(false);
+  };
+
+  const changeValue = (category: string, delta: number) => {
+    setValues((prev) => ({
+      ...prev,
+      [category]: (Math.max(0, parseFloat(prev[category] || "0") + delta)).toFixed(2),
+    }));
+  };
+
+  const handleInputChange = (category: string, value: string) => {
+    setValues((prev) => ({
+      ...prev,
+      [category]: value,
+    }));
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Manage Budgets</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          {budgets?.map((budget) => (
+            <div key={budget.id} className="flex items-center justify-between">
+              <span className="flex-1">{budget.category}</span>
+              <div className="flex items-center space-x-2">
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={() => changeValue(budget.category, -10)}
+                  data-testid={`decrease-${budget.category.toLowerCase().replace(/\s+/g, '-')}`}
+                >
+                  <ChevronDown className="h-4 w-4" />
+                </Button>
+                <Input
+                  type="number"
+                  value={values[budget.category] || ""}
+                  onChange={(e) => handleInputChange(budget.category, e.target.value)}
+                  className="w-24 text-right"
+                  data-testid={`input-${budget.category.toLowerCase().replace(/\s+/g, '-')}`}
+                />
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={() => changeValue(budget.category, 10)}
+                  data-testid={`increase-${budget.category.toLowerCase().replace(/\s+/g, '-')}`}
+                >
+                  <ChevronUp className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+        <DialogFooter>
+          <Button onClick={handleSave} data-testid="button-save-budgets">Save</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/recent-transactions.tsx
+++ b/client/src/components/recent-transactions.tsx
@@ -62,8 +62,10 @@ export default function RecentTransactions() {
   const formatCurrency = (amount: string) => {
     return new Intl.NumberFormat("en-US", {
       style: "currency",
-      currency: "USD",
-    }).format(parseFloat(amount));
+      currency: "MAD",
+    })
+      .format(parseFloat(amount))
+      .replace("MAD", "DH");
   };
 
   const formatDate = (date: string) => {

--- a/client/src/components/spending-analytics.tsx
+++ b/client/src/components/spending-analytics.tsx
@@ -86,11 +86,11 @@ export default function SpendingAnalytics() {
                 tickLine={false}
                 tick={{ fontSize: 12, fill: '#6B7280' }}
               />
-              <YAxis 
+              <YAxis
                 axisLine={false}
                 tickLine={false}
                 tick={{ fontSize: 12, fill: '#6B7280' }}
-                tickFormatter={(value) => `$${value}`}
+                tickFormatter={(value) => `${value} DH`}
               />
               <Line 
                 type="monotone" 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,7 +1,7 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
-import { insertTransactionSchema, insertBudgetSchema } from "@shared/schema";
+import { insertTransactionSchema, insertBudgetSchema, updateBudgetSchema } from "@shared/schema";
 import { z } from "zod";
 
 export async function registerRoutes(app: Express): Promise<Server> {
@@ -63,6 +63,24 @@ export async function registerRoutes(app: Express): Promise<Server> {
         res.status(400).json({ message: "Invalid budget data", errors: error.errors });
       } else {
         res.status(500).json({ message: "Failed to create budget" });
+      }
+    }
+  });
+
+  app.put("/api/budgets/:category", async (req, res) => {
+    try {
+      const { category } = req.params;
+      const validatedData = updateBudgetSchema.parse(req.body);
+      const budget = await storage.updateBudgetLimit(category, validatedData.monthlyLimit);
+      if (!budget) {
+        return res.status(404).json({ message: "Budget not found" });
+      }
+      res.json(budget);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        res.status(400).json({ message: "Invalid budget data", errors: error.errors });
+      } else {
+        res.status(500).json({ message: "Failed to update budget" });
       }
     }
   });
@@ -161,7 +179,7 @@ async function generateInsights(transaction: any) {
       await storage.createInsight({
         type: "warning",
         title: "Budget Exceeded",
-        message: `You've exceeded your ${transaction.category} budget by $${(parseFloat(budget.currentSpent) - parseFloat(budget.monthlyLimit)).toFixed(2)} this month.`,
+        message: `You've exceeded your ${transaction.category} budget by DH${(parseFloat(budget.currentSpent) - parseFloat(budget.monthlyLimit)).toFixed(2)} this month.`,
         category: transaction.category,
         isRead: "false"
       });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -13,6 +13,7 @@ export interface IStorage {
   getBudgetByCategory(category: string): Promise<Budget | undefined>;
   createBudget(budget: InsertBudget): Promise<Budget>;
   updateBudgetSpent(category: string, amount: number): Promise<Budget | undefined>;
+  updateBudgetLimit(category: string, monthlyLimit: string): Promise<Budget | undefined>;
   
   // Insights
   getInsights(): Promise<Insight[]>;
@@ -115,6 +116,16 @@ export class MemStorage implements IStorage {
     if (budget) {
       const currentSpent = parseFloat(budget.currentSpent) + amount;
       budget.currentSpent = currentSpent.toFixed(2);
+      this.budgets.set(budget.id, budget);
+      return budget;
+    }
+    return undefined;
+  }
+
+  async updateBudgetLimit(category: string, monthlyLimit: string): Promise<Budget | undefined> {
+    const budget = await this.getBudgetByCategory(category);
+    if (budget) {
+      budget.monthlyLimit = parseFloat(monthlyLimit).toFixed(2);
       this.budgets.set(budget.id, budget);
       return budget;
     }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -34,12 +34,18 @@ export const insights = pgTable("insights", {
 export const insertTransactionSchema = createInsertSchema(transactions).omit({
   id: true,
   createdAt: true,
+}).extend({
+  date: z.coerce.date(),
 });
 
 export const insertBudgetSchema = createInsertSchema(budgets).omit({
   id: true,
   currentSpent: true,
   createdAt: true,
+});
+
+export const updateBudgetSchema = z.object({
+  monthlyLimit: z.string(),
 });
 
 export const insertInsightSchema = createInsertSchema(insights).omit({
@@ -51,5 +57,6 @@ export type InsertTransaction = z.infer<typeof insertTransactionSchema>;
 export type Transaction = typeof transactions.$inferSelect;
 export type InsertBudget = z.infer<typeof insertBudgetSchema>;
 export type Budget = typeof budgets.$inferSelect;
+export type UpdateBudget = z.infer<typeof updateBudgetSchema>;
 export type InsertInsight = z.infer<typeof insertInsightSchema>;
 export type Insight = typeof insights.$inferSelect;


### PR DESCRIPTION
## Summary
- enable updating budget limits with a manage budgets dialog
- support budget updates on the backend
- display Moroccan Dirham (DH) instead of USD

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68ac932f3914832186f51bd8fd08eca1